### PR TITLE
fix: fix todo template name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ using the the [`oracledb` database driver](https://github.com/oracle/node-oracle
     [React](https://react.dev/). It is built by [`vite`](https://vitejs.dev/)
 - `node-vue`: A starter template that uses Node.js and
     [Vue.js](https://vuejs.org/). It is built by [`vite`](https://vitejs.dev/)
-- `node-todo`: A simple task manager template that uses Node.js and
+- `node-react-todo`: A simple task manager template that uses Node.js and
     [React](https://react.dev/). It demonstrates the use of the database for
     Create, Read, Update and Delete (CRUD) operations. It is built by
     [`vite`](https://vitejs.dev/)
@@ -95,7 +95,7 @@ template, you can execute:
 ```sh
 npm create @oracle/database-app -- \
     --name 'my-todo' \
-    --template 'node-todo'
+    --template 'node-react-todo'
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oracle/create-database-app",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oracle/create-database-app",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "bundleDependencies": [
         "@inquirer/prompts",
         "@oclif/core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oracle/create-database-app",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Create an Oracle Database Application from a Template",
   "author": "Oracle Corporation",
   "keywords": [


### PR DESCRIPTION
The todo template was referred as node-todo vs the correct name node-react-todo.

Fixes #11 