### PR TITLE
Fix hydration errors

### DIFF
--- a/templates/ords-remix-jwt-sample/app/components/concerts/ConcertCard.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/concerts/ConcertCard.tsx
@@ -95,7 +95,7 @@ function ConcertCard(props: ConcertCardProps) {
             </Link>
             <div className="flex items-center">
               <CalendarMonth />
-              <p className="font-sans font-extralight">
+              <p className="font-sans font-extralight" suppressHydrationWarning>
                 { concertDateString }
               </p>
             </div>

--- a/templates/ords-remix-jwt-sample/app/components/concerts/ConcertDetails.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/concerts/ConcertDetails.tsx
@@ -50,7 +50,7 @@ function ConcertDetails(props: ConcertDetailsProps) {
           <h1 className="mb-5 text-justify text-xl font-bold">
             Additional Details
           </h1>
-          <p className="mb-2 text-justify font-normal">
+          <p className="mb-2 text-justify font-normal" suppressHydrationWarning>
             {`Get ready for an unforgettable evening with ${concert.items[0].artist_name}!
                     Join us at ${concert.items[0].venue_name} on ${concertDateString} for a night of incredible
                     music and electrifying performances.

--- a/templates/ords-remix-jwt-sample/app/components/homepage/ConcertCard.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/homepage/ConcertCard.tsx
@@ -59,7 +59,7 @@ function ConcertCard(props: ConcertCardProps) {
             </div>
             <div className="flex items-center">
               <CalendarMonth />
-              <p className="font-sans font-extralight">
+              <p className="font-sans font-extralight" suppressHydrationWarning>
                 { concertDateString }
               </p>
             </div>

--- a/templates/ords-remix-jwt-sample/app/components/homepage/Timeline.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/homepage/Timeline.tsx
@@ -128,9 +128,9 @@ function Timeline(props: TimelineProps) {
                   },
                 }}
               >
-                <StyledTab className="w-1/3" label={today.toDateString()} {...a11yProps(0)} />
-                <StyledTab className="w-1/3" label={tomorrow.toDateString()} {...a11yProps(1)} />
-                <StyledTab className="w-1/3" label={dayAfterTomorrow.toDateString()} {...a11yProps(LAST_TAB)} />
+                <StyledTab className="w-1/3" label={today.toDateString()} {...a11yProps(0)} suppressHydrationWarning />
+                <StyledTab className="w-1/3" label={tomorrow.toDateString()} {...a11yProps(1)} suppressHydrationWarning />
+                <StyledTab className="w-1/3" label={dayAfterTomorrow.toDateString()} {...a11yProps(LAST_TAB)} suppressHydrationWarning />
               </Tabs>
             </div>
           </Box>

--- a/templates/ords-remix-jwt-sample/app/components/private/FollowedEventCard.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/private/FollowedEventCard.tsx
@@ -38,7 +38,7 @@ function FollowedEventCard(props: FollowedEventCardProps) {
           <div className="mx-4">
             <div className="mb-2 flex items-center">
               <CalendarMonth />
-              <p className="font-sans font-extralight">
+              <p className="font-sans font-extralight" suppressHydrationWarning >
                 { concertDateString }
               </p>
             </div>

--- a/templates/ords-remix-jwt-sample/app/components/search/ConcertResultCard.tsx
+++ b/templates/ords-remix-jwt-sample/app/components/search/ConcertResultCard.tsx
@@ -49,7 +49,7 @@ function ConcertResultCard(props: ConcertResultCardProps) {
               </h1>
               <div className="flex items-center">
                 <CalendarMonth />
-                <p className="font-sans font-extralight">
+                <p className="font-sans font-extralight" suppressHydrationWarning>
                   { concertDateString }
                 </p>
               </div>


### PR DESCRIPTION
# [PR] Fix hydration errors

## Description
While working on a docker image for the `ords-remix-jwt-sample` it was discovered that several hydration errors where thrown in some pages of the project, this was caused by a mismatch between the client and server date used in some components to render events information. 


```js
Warning: Text content did not match. Server: "Monday September 9, 2024" Client: "Sunday September 8, 2024" p div div div withEmotionCache2/<@http://dbtools-dev.oraclecorp.com:3000/build/_shared/chunk-4M4ZAFAD.js:2360:46 CardContent2@http://dbtools-dev.oraclecorp.com:3000/build/_shared/chunk-4M4ZAFAD.js:16021:33 div withEmotionCache2/<@http://dbtools-dev.oraclecorp.com:3000/build/_shared/chunk-4M4ZAFAD.js:2360:46 
....
``` 

To fix this, we suppress this hydration warning since other alternatives involved the rewriting of some endpoints that would be too costly and for some other use cases, like the timeline feature of the home page, it would be impossible to implement it otherwise. 

Fixes # (issue number)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [N/A]  New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [N/A] This change requires a documentation update
    
## How Has This Been Tested?

    Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Create a project using the `ords-remix-jwt-sample` template.
2. Complete the required setup for the project to work. 
3. Launch the project.
4. In Chrome, or other navigator, change the navigator (client) timezone. 
5. Open the app in the recently modified navigator.

Note that there are no hydration errors in the console and the app works as expected. 

 ## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
