### PR TITLE
chore(docs): make it clear that some privileges are dependent of the schema name

### DIFF
--- a/templates/ords-remix-jwt-sample/ords/security/README.MD
+++ b/templates/ords-remix-jwt-sample/ords/security/README.MD
@@ -147,15 +147,18 @@ This is the audience that both the ORDS Sample App and the ORDS JWT Client will 
 
 Now that we have created our API, go to the `Permissions` tab and grant it the following permissions/privileges.
 
+> [!IMPORTANT]
+> Replace <SCHEMA_NAME> with the `SCHEMA_NAME` variable specified on your `.env` file. 
+
 | Permission | Description | What it does in the ORDS Sample App |
 | ---------- | ----------- | ----------- |
 |read:general_user_content | Read all of the general user endpoints |  Allows the Sample App to read user information like first name, last name, email and Auth0 ID |
 | concert_app_authuser | Provides access to the user specific endpoints |  Allows authenticated users to interact with user specific ORDS Endpoints, like subscribing to a concert and more. |
 | concert_app_euser | Provides limited access to the concert app endpoints | Allows unauthenticated users to interact with limited ORDS Endpoints. |
 | concert_app_admin | Provides access to the concert app admin endpoints | Allows authenticated admin users to interact with user specific ORDS Endpoints, like the create or delete Artist Endpoints. |
-| oracle.dbtools.autorest.privilege.CONCERT_SAMPLE_APP.SEARCH_VIEW | Provides access to the AutoREST search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
-oracle.dbtools.autorest.privilege.CONCERT_SAMPLE_APP.SEARCH_ARTIST_VIEW | Provides access to the AutoREST artists search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
-| oracle.dbtools.autorest.privilege.CONCERT_SAMPLE_APP.SEARCH_VENUES_VIEW | Provides access to the AutoREST venues search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
+| oracle.dbtools.autorest.privilege.`<SCHEMA_NAME>`.SEARCH_VIEW | Provides access to the AutoREST search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
+oracle.dbtools.autorest.privilege.`<SCHEMA_NAME>`.SEARCH_ARTIST_VIEW | Provides access to the AutoREST artists search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
+| oracle.dbtools.autorest.privilege.`<SCHEMA_NAME>`.SEARCH_VENUES_VIEW | Provides access to the AutoREST venues search view. | Allows every user of the ORDS Concert App to access the search/discover functionality. |
 
 Once you have added all of the permissions described above your list of permissions should look like this. 
 


### PR DESCRIPTION
# [PR] Make it clear that some privileges are dependent of the schema name

## Description

Improve the `ORDS Concert App - Securing the Services` README file to make it clear that some of the privileges required for the sample app to work are dependent of the name of the schema. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds functionality)
- [N/A] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [N/A] This change requires a documentation update
    
## How Has This Been Tested?

Since this is doc change, just confirmed the there are no typos and no breaking changes on the format. See https://github.com/oracle/create-database-app/blob/0aa53533c75fda42308ece1d35365d55df4075c8/templates/ords-remix-jwt-sample/ords/security/README.MD 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas1
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
