### PR TITLE
Removed use of Basic authentication for the sample app.

### DIFF
--- a/templates/ords-remix-jwt-sample/app/root.tsx
+++ b/templates/ords-remix-jwt-sample/app/root.tsx
@@ -30,7 +30,6 @@ import {
 } from './utils/auth.server';
 import NavBar from './components/navbar/NavBar';
 import {
-  BASIC_SCHEMA_AUTH,
   CITIES_ENDPOINT,
 } from './routes/constants/index.server';
 import TooltipButton from './components/tooltips/TooltipButton';
@@ -42,7 +41,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const profile = userProfile?.profile || null;
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/artists.$id.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/artists.$id.tsx
@@ -22,7 +22,6 @@ import {
   ARTISTS_ENDPOINT,
   ARTIST_ENDPOINT,
   ARTIST_EVENT_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
   CITIES_ENDPOINT,
   LIKED_ARTIST_ENDPOINT,
 } from './constants/index.server';
@@ -87,7 +86,7 @@ export const loader = async ({
   const userProfile = await auth.isAuthenticated(request);
   const profile = userProfile?.profile || null;
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/concerts.$concertID.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/concerts.$concertID.tsx
@@ -29,7 +29,6 @@ import ConcertDetails from '../components/concerts/ConcertDetails';
 import {
   EVENT_ENDPOINT,
   LIKED_EVENT_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
 } from './constants/index.server';
 import { UserActions } from '../utils/UserActions';
 import ORDSFetcher from '../utils/ORDSFetcher';
@@ -93,7 +92,7 @@ export const loader = async ({
   const userProfile = await auth.isAuthenticated(request);
   const profile = userProfile?.profile || null;
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/home.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/home.tsx
@@ -23,7 +23,6 @@ import {
 } from '../utils/auth.server';
 import {
   STATS_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
   EVENTS_ENDPOINT,
   ARTISTS_ENDPOINT,
   CONCERTS_BY_CITY_ENDPOINT,
@@ -43,7 +42,7 @@ import featureDescriptions from '../utils/ORDSFeaturesDescription';
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/resources.artists.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/resources.artists.tsx
@@ -15,7 +15,6 @@ import {
 } from '~/utils/auth.server';
 import {
   ARTISTS_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
 } from './constants/index.server';
 import ORDSFetcher from '../utils/ORDSFetcher';
 
@@ -29,7 +28,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   artistsURL.searchParams.append('limit', limit.toString());
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/resources.cities.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/resources.cities.tsx
@@ -15,7 +15,6 @@ import {
 } from '~/utils/auth.server';
 import {
   CITIES_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
 } from './constants/index.server';
 import ORDSFetcher from '../utils/ORDSFetcher';
 
@@ -29,7 +28,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   citiesURL.searchParams.append('limit', limit.toString());
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/resources.concerts.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/resources.concerts.tsx
@@ -15,7 +15,6 @@ import {
 } from '~/utils/auth.server';
 import {
   EVENTS_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
   CONCERTS_BY_CITY_ENDPOINT,
 } from './constants/index.server';
 import ORDSFetcher from '../utils/ORDSFetcher';
@@ -33,7 +32,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   eventsURL.searchParams.append('limit', limit.toString());
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/resources.musicGenres.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/resources.musicGenres.tsx
@@ -14,7 +14,6 @@ import {
   getSession,
 } from '~/utils/auth.server';
 import {
-  BASIC_SCHEMA_AUTH,
   MUSIC_GENRES_ENDPOINT,
 } from './constants/index.server';
 import ORDSFetcher from '../utils/ORDSFetcher';
@@ -31,7 +30,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   musicGenresURL.searchParams.append('limit', limit.toString());
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/resources.venues.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/resources.venues.tsx
@@ -15,7 +15,6 @@ import {
 } from '~/utils/auth.server';
 import {
   VENUES_ENDPOINT,
-  BASIC_SCHEMA_AUTH,
 } from './constants/index.server';
 import ORDSFetcher from '../utils/ORDSFetcher';
 import ORDSResponse from '../models/ORDSResponse';
@@ -31,7 +30,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   venuesURL.searchParams.append('limit', limit.toString());
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/search.$searchKind.$searchParam.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/search.$searchKind.$searchParam.tsx
@@ -11,7 +11,6 @@ import type {
 import { json } from '@remix-run/node';
 import { auth } from '~/utils/auth.server';
 import {
-  BASIC_SCHEMA_AUTH,
   ARTISTS_ENDPOINT,
   VENUES_ENDPOINT,
   EVENTS_BY_NAME_ENDPOINT,
@@ -30,7 +29,7 @@ export const loader = async ({
   const { searchKind, searchParam } = params;
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   // eslint-disable-next-line no-magic-numbers
   const FOLLOWERS = [69420, 99876, 45632, 32496, 98765, 12776, 100000, 88999, 99999];

--- a/templates/ords-remix-jwt-sample/app/routes/search.artists.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/search.artists.tsx
@@ -20,7 +20,6 @@ import {
   auth, getSession,
 } from '../utils/auth.server';
 import {
-  BASIC_SCHEMA_AUTH,
   MUSIC_GENRES_ENDPOINT,
   AUTO_REST_SEARCH_ARTISTS_ENDPOINT,
 } from './constants/index.server';
@@ -34,7 +33,7 @@ import DiscoverArtists from '../components/search/DiscoverArtists';
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/search.concerts.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/search.concerts.tsx
@@ -20,7 +20,6 @@ import {
   auth, getSession,
 } from '../utils/auth.server';
 import {
-  BASIC_SCHEMA_AUTH,
   AUTO_REST_SEARCH_ENDPOINT,
   CITIES_ENDPOINT,
   ARTISTS_ENDPOINT,
@@ -38,7 +37,7 @@ import Artist from '../models/Artist';
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/search.venues.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/search.venues.tsx
@@ -20,7 +20,6 @@ import {
   auth, getSession,
 } from '../utils/auth.server';
 import {
-  BASIC_SCHEMA_AUTH,
   AUTO_REST_SEARCH_VENUES_ENDPOINT,
   CITIES_ENDPOINT,
 } from './constants/index.server';
@@ -34,7 +33,7 @@ import ORDSResponse from '../models/ORDSResponse';
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/app/routes/venues.tsx
+++ b/templates/ords-remix-jwt-sample/app/routes/venues.tsx
@@ -11,7 +11,7 @@ import {
   auth,
   getSession,
 } from '~/utils/auth.server';
-import { BASIC_SCHEMA_AUTH, VENUES_ENDPOINT } from './constants/index.server';
+import { VENUES_ENDPOINT } from './constants/index.server';
 import { LoaderError } from '../models/LoaderError';
 import ORDSFetcher from '../utils/ORDSFetcher';
 import Venue from '../models/Venue';
@@ -22,7 +22,7 @@ export const loader = async ({
 }: LoaderFunctionArgs) => {
   const userProfile = await auth.isAuthenticated(request);
   const USER_CREDENTIALS = userProfile === null
-    ? BASIC_SCHEMA_AUTH
+    ? ''
     : `${userProfile.tokenType} ${userProfile.accessToken}`;
   const session = await getSession(request.headers.get('Cookie'));
   const error = session.get(auth.sessionErrorKey) as LoaderError;

--- a/templates/ords-remix-jwt-sample/ords/migrateScripts/protectEndpoints.js
+++ b/templates/ords-remix-jwt-sample/ords/migrateScripts/protectEndpoints.js
@@ -50,13 +50,6 @@ async function protectEndpoints(
     'concert_app.adminuser.v1',
   )}
 
-  ${definePrivilege(
-    'concert_app_euser',
-    'Non authenticated end user privilege',
-    'Provides limited access to the concert app endpoints',
-    'concert_app.euser.v1',
-  )}
-
         COMMIT;
     END;
     /


### PR DESCRIPTION
# [PR] Removed use of Basic authentication for the sample app.

    ## Description
    The ords-remix-jwt-sample template was originally using Basic authentication when executing requests to the different handlers defined in ORDS. Since using Basic auth is not really a best practice, a ticket was opened to remove it. Instead, the end user endpoints are no longer protected and can be accessed by any user. The end user can only execute read-only actions, so it is fine to have it public. 

    Fixes # (issue number)

    ## Type of change
    - [x] Bug fix (non-breaking change which fixes an issue)
    - [ ] New feature (non-breaking change which adds functionality)
    - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
    - [ ] This change requires a documentation update
    
    ## How Has This Been Tested?
    In order to test what type of auth is used, requests were made throughout the application using both the normal end user and an authenticated user. Logs were printed inside the `ORDSFetcher` function to compare the `authCredentials` being used when the user requests the home page.

    - [ ] End User
```
AUTH:  
AUTH:  
AUTH:  
AUTH:  
GET /home 200 - - 2147.232 ms
```

    - [ ] Authenticated User
```
AUTH:  Bearer <token>
AUTH:  Bearer <token>
AUTH:  Bearer <token>
AUTH:  Bearer <token>
GET /home 200 - - 1829.794 ms
```

    ## Checklist:
    - [x] My code follows the style guidelines of this project
    - [x] I have performed a self-review of my own code
    - [ ] I have commented my code, particularly in hard-to-understand areas
    - [n/a] I have made corresponding changes to the documentation
    - [x] My changes generate no new warnings/errors
    - [x] I have added tests that prove my fix is effective or that my feature works
    - [n/a] New and existing unit tests pass locally with my changes
