### PR TITLE
fix(deps): bump node-jet template to JET v17.1

### DIFF
--- a/templates/node-jet/oraclejetconfig.json
+++ b/templates/node-jet/oraclejetconfig.json
@@ -15,13 +15,15 @@
       "themes": "staged-themes"
     }
   },
+  "unversioned": true,
   "defaultBrowser": "chrome",
-  "sassVer": "8.0.0",
+  "sassVer": "9.0.0",
   "defaultTheme": "redwood",
-  "typescriptLibraries": "typescript@5.3.2 yargs-parser@~13.1.2",
+  "fontUrl": "https://static.oracle.com/cdn/fnd/gallery/2404.0.0/images/iconfont/ojuxIconFont.min.css",
+  "typescriptLibraries": "typescript@5.4.5 yargs-parser@~13.1.2",
   "webpackLibraries": "webpack@5.76.0 @types/node@18.16.3 webpack-dev-server style-loader css-loader sass-loader sass ts-loader@8.4.0 raw-loader noop-loader html-webpack-plugin html-replace-webpack-plugin copy-webpack-plugin @prefresh/webpack @prefresh/babel-plugin webpack-merge compression-webpack-plugin mini-css-extract-plugin clean-webpack-plugin css-fix-url-loader",
   "mochaTestingLibraries": "karma mocha sinon chai@4.4.1 coverage karma-chai@0.1.0 karma-coverage@2.2.0 karma-chrome-launcher@3.1.1 karma-mocha@2.0.1 karma-mocha-reporter@2.2.5 karma-requirejs@1.1.0 karma-fixture@0.2.6 karma-sinon@1.0.5 karma-typescript@5.5.4 @types/chai@4.3.4 @types/karma-fixture@0.2.5 @types/mocha@10.0.1 @types/sinon@10.0.13",
-  "jestTestingLibraries": "jest@29.6.2 @testing-library/preact@3.2.3 @types/jest@29.5.3 jest-environment-jsdom@29.6.2 @oracle/oraclejet-jest-preset@~16.1.0",
+  "jestTestingLibraries": "jest@29.6.2 @testing-library/preact@3.2.3 @types/jest@29.5.3 jest-environment-jsdom@29.6.2 @oracle/oraclejet-jest-preset@~17.1.0",
   "architecture": "vdom",
   "watchInterval": 1000
 }

--- a/templates/node-jet/package.json
+++ b/templates/node-jet/package.json
@@ -7,28 +7,28 @@
     "lint": "eslint src/ --max-warnings 0"
   },
   "dependencies": {
-    "@oracle/oraclejet": "~17.0.1",
-    "@oracle/oraclejet-core-pack": "~17.0.1",
-    "body-parser": "^1.20.2",
+    "@oracle/oraclejet": "~17.1.0",
+    "@oracle/oraclejet-core-pack": "~17.1.0",
+    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
-    "express": "^4.19.2",
-    "http-proxy-middleware": "^3.0.0",
-    "morgan": "^1.10.0",
-    "oracledb": "^6.6.0"
+    "dotenv": "16.4.7",
+    "express": "4.21.2",
+    "http-proxy-middleware": "3.0.3",
+    "morgan": "1.10.0",
+    "oracledb": "6.7.1"
   },
   "devDependencies": {
-    "@oracle/ojet-cli": "~17.0.0",
-    "concurrently": "^8.2.2",
-    "extract-zip": "^2.0.1",
-    "fs-extra": "^11.2.0",
-    "glob": "^11.0.0",
-    "typescript": "^5.5.4",
-    "underscore": "^1.13.7",
-    "yargs-parser": "21.1.1",
-    "eslint": "^9.9.1",
-    "@eslint/js": "^9.9.1",
-    "typescript-eslint": "8.3.0"
+    "@oracle/ojet-cli": "~17.1.0",
+    "extract-zip": "^1.7.0",
+    "fs-extra": "^8.1.0",
+    "glob": "10.4.5",
+    "typescript": "5.4.5",
+    "underscore": "^1.10.2",
+    "yargs-parser": "13.1.2",
+    "concurrently": "^9.1.2",
+    "eslint": "^9.18.0",
+    "@eslint/js": "^9.18.0",
+    "typescript-eslint": "8.20.0"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/templates/node-jet/path_mapping.json
+++ b/templates/node-jet/path_mapping.json
@@ -2,12 +2,12 @@
   "use": "local",
   "cdns": {
     "jet": {
-      "prefix": "https://static.oracle.com/cdn/jet/16.1.0/default/js",
-      "css": "https://static.oracle.com/cdn/jet/16.1.0/default/css",
-      "csspreact": "https://static.oracle.com/cdn/jet/16.1.0/3rdparty/oraclejet-preact/amd",
+      "prefix": "https://static.oracle.com/cdn/jet/17.1.0/default/js",
+      "css": "https://static.oracle.com/cdn/jet/17.1.0/default/css",
+      "csspreact": "https://static.oracle.com/cdn/jet/17.1.0/3rdparty/oraclejet-preact/amd",
       "config": "bundles-config.js"
     },
-    "3rdparty": "https://static.oracle.com/cdn/jet/16.1.0/3rdparty"
+    "3rdparty": "https://static.oracle.com/cdn/jet/17.1.0/3rdparty"
   },
   "libs": {
     "knockout": {

--- a/templates/node-jet/src/index.html
+++ b/templates/node-jet/src/index.html
@@ -35,7 +35,8 @@
 		<!-- injector:theme -->
 		<!-- endinjector -->
     <!-- This contains icon fonts used by the starter template -->
-    <link rel="stylesheet" id="uxiconFont" href="https://static.oracle.com/cdn/fnd/gallery/2404.0.0/images/iconfont/ojuxIconFont.min.css"/>
+		<!-- injector:font -->
+		<!-- endinjector:font -->
     <!-- This is where you would add any app specific styling -->
     <link rel="stylesheet" href="styles/app.css" type="text/css" />
   </head>

--- a/templates/node-jet/src/main.js
+++ b/templates/node-jet/src/main.js
@@ -25,9 +25,9 @@
       */
       // injector:mainReleasePaths
       {
-        'ojs': 'libs/oj/16.1.0/debug',
-        'ojL10n': 'libs/oj/16.1.0/ojL10n',
-        'ojtranslations': 'libs/oj/16.1.0/resources',
+        'ojs': 'libs/oj/17.1.0/debug',
+        'ojL10n': 'libs/oj/17.1.0/ojL10n',
+        'ojtranslations': 'libs/oj/17.1.0/resources',
           'knockout': 'libs/knockout/knockout-3.5.1.debug',
   'jquery': 'libs/jquery/jquery-3.6.4',
   'jqueryui-amd': 'libs/jquery/jqueryui-amd-1.13.2',


### PR DESCRIPTION
# bump `node-jet` template to JET v17.1

The template was generated again using the ojet CLI `v17.1.0`, and the rest of dependencies added on top of it were updated to the latest version available. 