### PR TITLE
fix(deps): ords-remix-jwt-sample dependencies

### DIFF
--- a/templates/ords-remix-jwt-sample/package.json
+++ b/templates/ords-remix-jwt-sample/package.json
@@ -38,10 +38,10 @@
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "5.16.14",
     "@mui/material": "5.16.14",
-    "@remix-run/dev": "2.16.5",
-    "@remix-run/node": "2.16.5",
-    "@remix-run/react": "2.16.5",
-    "@remix-run/serve": "2.16.5",
+    "@remix-run/dev": "2.16.8",
+    "@remix-run/node": "2.16.8",
+    "@remix-run/react": "2.16.8",
+    "@remix-run/serve": "2.16.8",
     "dotenv": "^16.4.5",
     "embla-carousel": "^8.2.0",
     "embla-carousel-react": "^8.2.0",
@@ -54,7 +54,7 @@
     "react-dom": "18.3.1",
     "remix-auth": "3.7.0",
     "remix-auth-auth0": "1.10.0",
-    "vite": "5.4.14"
+    "vite": "5.4.19"
   },
   "devDependencies": {
     "@svgr/cli": "8.1.0",
@@ -65,7 +65,7 @@
     "@types/react-dom": "18.3.0",
     "@typescript-eslint/eslint-plugin": "7.15.0",
     "@typescript-eslint/parser": "7.15.0",
-    "autoprefixer": "10.4.20",
+    "autoprefixer": "10.4.21",
     "eslint": "8.57.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-airbnb-base": "15.0.0",
@@ -80,7 +80,7 @@
     "eslint-plugin-tsdoc": "0.4.0",
     "postcss": "8.4.47",
     "tailwindcss": "3.4.3",
-    "typescript": "5.1.6",
+    "typescript": "5.8.3",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }


### PR DESCRIPTION
# fix(deps): ords-remix-jwt-sample dependencies

## Description

Updates the following ` ords-remix-jwt-sample` template dependencies:

| Package | From | To |
| --- | --- | --- |
| [@remix-run/node](https://github.com/remix-run/remix/tree/HEAD/packages/remix-node) | `2.15.5` | `2.16.8` |
| [@remix-run/react](https://github.com/remix-run/remix/tree/HEAD/packages/remix-react) | `2.15.5` | `2.16.8` |
| [@remix-run/serve](https://github.com/remix-run/remix/tree/HEAD/packages/remix-serve) | `2.15.5` | `2.16.8` |
| [@remix-run/dev](https://github.com/remix-run/remix/tree/HEAD/packages/remix-dev) | `2.15.5` | `2.16.8` |
| [vite](https://github.com/vitejs/vite) | `5.4.14` | `5.4.19` |
| [autoprefixer](https://github.com/postcss/autoprefixer#readme) | `10.4.20` | `10.4.21` |
| [typescript](https://github.com/microsoft/TypeScript) | `5.1.6` | `5.8.3` |

Regarding the `mui-dependencies` group dependencies updates (github.com/oracle/create-database-app/pull/272):  It's not currently possible to update the `@mui/material` and `@mui/icons-material` dependencies from `5.16.14` to `7.0.2` since it seems to have introduced a breaking change in the way some of the components get imported and other compatibility issues with the version of remix and react that we are currently using.

Regarding the `ords-react-dependencies` group dependencies updates (https://github.com/oracle/create-database-app/pull/273), it is not possible to update from `react` `18.3.1` to `19.1.0` given that the current version of Remix does not fully supports this version of react. There is a [Incremental Path to adopt React 19](https://remix.run/blog/incremental-path-to-react-19) that we are monitoring closely. The current status of this incremental path is to drop Remix V2 since it's being sunsetted and is currently in [maintenance mode](https://github.com/remix-run/remix?tab=readme-ov-file#welcome-to-remix) and adopt react-router 7 following the [Upgrading from Remix Guide](https://reactrouter.com/upgrading/remix). We need to discuss this since dropping Remix has some implications (particularly changing the name of the template and documentation changes). 

Fixes # (issue number)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Updated the dependencies listed above in the `package.json` file of the `ords-remix-jwt-sample` template.
- Generated a new project from that template.
- Executed the `dev` command of the project and confirmed that there were no import errors.
- Did a full scan of the project and confirmed that everything worked as expected. 


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings/errors
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
